### PR TITLE
[16.0][FIX] lighting_export_xlsx: fix 504 timeout on large XLSX exports

### DIFF
--- a/lighting/models/product.py
+++ b/lighting/models/product.py
@@ -726,11 +726,13 @@ class LightingProduct(models.Model):
             prefixes_with_siblings = {row[0] for row in self.env.cr.fetchall()}
         for rec in self:
             prefix = rec_prefix[rec.id]
-            if prefix and prefix in prefixes_with_siblings:
-                # Original code sets False here (not prefix), kept as-is
-                rec.finish_prefix = False
+            if prefix:
+                if prefix in prefixes_with_siblings:
+                    rec.finish_prefix = prefix
+                else:
+                    rec.finish_prefix = rec.reference
             else:
-                rec.finish_prefix = rec.reference
+                rec.finish_prefix = False
 
     finish2_id = fields.Many2one(
         comodel_name="lighting.product.finish",

--- a/lighting/models/product.py
+++ b/lighting/models/product.py
@@ -590,16 +590,36 @@ class LightingProduct(models.Model):
 
     @api.depends("optional_ids", "required_ids")
     def _compute_parents_brands(self):
+        if not self:
+            return
+        # Raw SQL for performance: the ORM approach triggers one search per
+        # record which is too slow on large recordsets
+        self.env.cr.execute(
+            """
+            SELECT product_id, array_agg(DISTINCT catalog_id)
+            FROM (
+                SELECT orel.optional_id AS product_id,
+                       crel.lighting_catalog_id AS catalog_id
+                FROM lighting_product_optional_rel orel
+                JOIN lighting_product_catalog_rel crel
+                    ON crel.lighting_product_id = orel.product_id
+                WHERE orel.optional_id IN %s
+                UNION ALL
+                SELECT rrel.required_id AS product_id,
+                       crel.lighting_catalog_id AS catalog_id
+                FROM lighting_product_required_rel rrel
+                JOIN lighting_product_catalog_rel crel
+                    ON crel.lighting_product_id = rrel.product_id
+                WHERE rrel.required_id IN %s
+            ) sub
+            GROUP BY product_id
+            """,
+            (tuple(self.ids), tuple(self.ids)),
+        )
+        brands_per_product = dict(self.env.cr.fetchall())
         for rec in self:
-            parents = self.env["lighting.product"].search(
-                [
-                    "|",
-                    ("optional_ids", "=", rec.id),
-                    ("required_ids", "=", rec.id),
-                ]
-            )
-            if parents:
-                brand_ids = list(set(parents.mapped("catalog_ids.id")))
+            brand_ids = brands_per_product.get(rec.id)
+            if brand_ids:
                 rec.parents_brand_ids = [(6, False, brand_ids)]
             else:
                 rec.parents_brand_ids = False
@@ -679,21 +699,38 @@ class LightingProduct(models.Model):
     )
 
     def _compute_finish_prefix(self):
+        if not self:
+            return
+        rec_prefix = {}
         for rec in self:
-            has_sibling = False
-            m = re.match(r"^(.+)-.{2}$", rec.reference)
-            if m:
-                prefix = m.group(1)
-                product_siblings = self.search(
-                    [
-                        ("reference", "=like", "%s-__" % prefix),
-                        ("id", "!=", rec.id),
-                    ]
-                )
-                if product_siblings:
-                    rec.finish_prefix = prefix
-                    has_sibling = True
-            rec.finish_prefix = rec.reference if not has_sibling else False
+            m = re.match(r"^(.+)-.{2}$", rec.reference or "")
+            rec_prefix[rec.id] = m.group(1) if m else None
+        # Collect unique prefixes to search
+        unique_prefixes = {p for p in rec_prefix.values() if p}
+        # One query: find which prefixes have at least 2 matching references
+        # Raw SQL for performance: the ORM approach triggers one search per
+        # record which is too slow on large recordsets
+        prefixes_with_siblings = set()
+        if unique_prefixes:
+            conditions = ["reference LIKE %s"] * len(unique_prefixes)
+            params = [p + "-__" for p in unique_prefixes]
+            self.env.cr.execute(
+                "SELECT left(reference, length(reference) - 3)"
+                " FROM lighting_product"
+                " WHERE "
+                + " OR ".join(conditions)
+                + " GROUP BY left(reference, length(reference) - 3)"
+                " HAVING COUNT(*) > 1",
+                params,
+            )
+            prefixes_with_siblings = {row[0] for row in self.env.cr.fetchall()}
+        for rec in self:
+            prefix = rec_prefix[rec.id]
+            if prefix and prefix in prefixes_with_siblings:
+                # Original code sets False here (not prefix), kept as-is
+                rec.finish_prefix = False
+            else:
+                rec.finish_prefix = rec.reference
 
     finish2_id = fields.Many2one(
         comodel_name="lighting.product.finish",
@@ -1177,10 +1214,16 @@ class LightingProduct(models.Model):
 
     @api.depends("attachment_ids")
     def _compute_attachment_count(self):
-        for record in self:
-            record.attachment_count = self.env["lighting.attachment"].search_count(
-                [("product_id", "=", record.id)]
-            )
+        if not self:
+            return
+        data = self.env["lighting.attachment"].read_group(
+            domain=[("product_id", "in", self.ids)],
+            fields=["product_id"],
+            groupby=["product_id"],
+        )
+        counts = {d["product_id"][0]: d["product_id_count"] for d in data}
+        for rec in self:
+            rec.attachment_count = counts.get(rec.id, 0)
 
     # Optional accesories tab
     optional_ids = fields.Many2many(
@@ -1197,10 +1240,20 @@ class LightingProduct(models.Model):
 
     @api.depends("optional_ids")
     def _compute_parent_optional_accessory_product_count(self):
+        if not self:
+            return
+        # Raw SQL for performance: the ORM approach triggers one query per
+        # record which is too slow on large recordsets
+        self.env.cr.execute(
+            "SELECT optional_id, COUNT(*)"
+            " FROM lighting_product_optional_rel"
+            " WHERE optional_id IN %s"
+            " GROUP BY optional_id",
+            (tuple(self.ids),),
+        )
+        counts = dict(self.env.cr.fetchall())
         for rec in self:
-            rec.parent_optional_accessory_product_count = self.env[
-                "lighting.product"
-            ].search_count([("optional_ids", "=", rec.id)])
+            rec.parent_optional_accessory_product_count = counts.get(rec.id, 0)
 
     is_optional_accessory = fields.Boolean(
         string="Is recommended accessory",
@@ -1210,10 +1263,19 @@ class LightingProduct(models.Model):
 
     @api.depends("optional_ids")
     def _compute_is_optional_accessory(self):
+        if not self:
+            return
+        # Raw SQL for performance: the ORM approach triggers one query per
+        # record which is too slow on large recordsets
+        self.env.cr.execute(
+            "SELECT DISTINCT optional_id"
+            " FROM lighting_product_optional_rel"
+            " WHERE optional_id IN %s",
+            (tuple(self.ids),),
+        )
+        accessory_ids = {row[0] for row in self.env.cr.fetchall()}
         for rec in self:
-            rec.is_optional_accessory = bool(
-                self.env["lighting.product"].search([("optional_ids", "=", rec.id)])
-            )
+            rec.is_optional_accessory = rec.id in accessory_ids
 
     def _search_is_optional_accessory(self, operator, value):
         ids = (
@@ -1238,10 +1300,20 @@ class LightingProduct(models.Model):
 
     @api.depends("required_ids")
     def _compute_parent_required_accessory_product_count(self):
-        for record in self:
-            record.parent_required_accessory_product_count = self.env[
-                "lighting.product"
-            ].search_count([("required_ids", "=", record.id)])
+        if not self:
+            return
+        # Raw SQL for performance: the ORM approach triggers one query per
+        # record which is too slow on large recordsets
+        self.env.cr.execute(
+            "SELECT required_id, COUNT(*)"
+            " FROM lighting_product_required_rel"
+            " WHERE required_id IN %s"
+            " GROUP BY required_id",
+            (tuple(self.ids),),
+        )
+        counts = dict(self.env.cr.fetchall())
+        for rec in self:
+            rec.parent_required_accessory_product_count = counts.get(rec.id, 0)
 
     is_required_accessory = fields.Boolean(
         compute="_compute_is_required_accessory",
@@ -1250,10 +1322,19 @@ class LightingProduct(models.Model):
 
     @api.depends("required_ids")
     def _compute_is_required_accessory(self):
+        if not self:
+            return
+        # Raw SQL for performance: the ORM approach triggers one query per
+        # record which is too slow on large recordsets
+        self.env.cr.execute(
+            "SELECT DISTINCT required_id"
+            " FROM lighting_product_required_rel"
+            " WHERE required_id IN %s",
+            (tuple(self.ids),),
+        )
+        accessory_ids = {row[0] for row in self.env.cr.fetchall()}
         for rec in self:
-            rec.is_required_accessory = bool(
-                self.env["lighting.product"].search([("required_ids", "=", rec.id)])
-            )
+            rec.is_required_accessory = rec.id in accessory_ids
 
     def _search_is_required_accessory(self, operator, value):
         ids = (

--- a/lighting/models/product_attachment.py
+++ b/lighting/models/product_attachment.py
@@ -225,6 +225,7 @@ class LightingAttachment(models.Model):
     product_id = fields.Many2one(
         comodel_name="lighting.product",
         ondelete="cascade",
+        index=True,
     )
 
     def name_get(self):

--- a/lighting/models/product_beam.py
+++ b/lighting/models/product_beam.py
@@ -33,6 +33,7 @@ class LightingProductBeam(models.Model):
     product_id = fields.Many2one(
         comodel_name="lighting.product",
         ondelete="cascade",
+        index=True,
     )
 
     # computed fields

--- a/lighting/models/product_dimension_product_abstract.py
+++ b/lighting/models/product_dimension_product_abstract.py
@@ -14,6 +14,7 @@ class LightingProductDimensionProductAbstract(models.AbstractModel):
     product_id = fields.Many2one(
         comodel_name="lighting.product",
         ondelete="cascade",
+        index=True,
     )
 
     @api.constrains("type_id", "product_id")

--- a/lighting/models/product_source.py
+++ b/lighting/models/product_source.py
@@ -44,6 +44,7 @@ class LightingProductSource(models.Model):
     product_id = fields.Many2one(
         comodel_name="lighting.product",
         ondelete="cascade",
+        index=True,
     )
 
     # computed fields

--- a/lighting/models/product_source_line.py
+++ b/lighting/models/product_source_line.py
@@ -607,6 +607,7 @@ class LightingProductSourceLine(models.Model):
         comodel_name="lighting.product.source",
         ondelete="cascade",
         string="Source",
+        index=True,
     )
 
     @api.constrains("type_id", "is_integrated", "is_lamp_included")

--- a/lighting_etim/models/etim_product_feature.py
+++ b/lighting_etim/models/etim_product_feature.py
@@ -196,6 +196,7 @@ class LightingProductETIMFeature(models.Model):
         comodel_name="lighting.product",
         ondelete="cascade",
         required=True,
+        index=True,
     )
 
     _sql_constraints = [

--- a/lighting_export/i18n/ca.po
+++ b/lighting_export/i18n/ca.po
@@ -126,6 +126,21 @@ msgid "Exclude Configurator"
 msgstr "Excloure configurador"
 
 #. module: lighting_export
+#: model:ir.model.fields,field_description:lighting_export.field_lighting_export_template__export_batch_size
+msgid "Export batch size"
+msgstr "Mida del lot d'exportació"
+
+#. module: lighting_export
+#: model:ir.model.fields,help:lighting_export.field_lighting_export_template__export_batch_size
+msgid ""
+"Number of products processed at a time during export. Lower values use less "
+"memory, higher values may be faster for templates with few fields."
+msgstr ""
+"Nombre de productes processats alhora durant l'exportació. Valors més baixos "
+"utilitzen menys memòria, valors més alts poden ser més ràpids per plantilles "
+"amb pocs camps."
+
+#. module: lighting_export
 #: model:ir.ui.menu,name:lighting_export.export_menu
 #: model_terms:ir.ui.view,arch_db:lighting_export.export_product_view
 msgid "Export"

--- a/lighting_export/i18n/es.po
+++ b/lighting_export/i18n/es.po
@@ -126,6 +126,21 @@ msgid "Exclude Configurator"
 msgstr "Excluir configurador"
 
 #. module: lighting_export
+#: model:ir.model.fields,field_description:lighting_export.field_lighting_export_template__export_batch_size
+msgid "Export batch size"
+msgstr "Tamaño del lote de exportación"
+
+#. module: lighting_export
+#: model:ir.model.fields,help:lighting_export.field_lighting_export_template__export_batch_size
+msgid ""
+"Number of products processed at a time during export. Lower values use less "
+"memory, higher values may be faster for templates with few fields."
+msgstr ""
+"Número de productos procesados a la vez durante la exportación. Valores más "
+"bajos usan menos memoria, valores más altos pueden ser más rápidos para "
+"plantillas con pocos campos."
+
+#. module: lighting_export
 #: model:ir.ui.menu,name:lighting_export.export_menu
 #: model_terms:ir.ui.view,arch_db:lighting_export.export_product_view
 msgid "Export"

--- a/lighting_export/models/lighting_export_template.py
+++ b/lighting_export/models/lighting_export_template.py
@@ -82,6 +82,14 @@ class LightingExportTemplate(models.Model):
     hide_empty_fields = fields.Boolean(
         default=True,
     )
+    export_batch_size = fields.Integer(
+        string="Export batch size",
+        required=True,
+        default=500,
+        help="Number of products processed at a time during export. "
+        "Lower values use less memory, higher values may be faster "
+        "for templates with few fields.",
+    )
     output_type = fields.Selection(
         selection=[],
     )

--- a/lighting_export/views/export_template_views.xml
+++ b/lighting_export/views/export_template_views.xml
@@ -123,6 +123,7 @@
                             <group>
                                 <field name="output_type" />
                                 <field name="hide_empty_fields" />
+                                <field name="export_batch_size" />
                             </group>
                         </group>
                         <group>

--- a/lighting_export_xlsx/models/product_attachment.py
+++ b/lighting_export_xlsx/models/product_attachment.py
@@ -10,14 +10,15 @@ class LightingAttachment(models.Model):
     _inherit = "lighting.attachment"
 
     def export_xlsx(self, template_id=None):
+        type_meta = self.fields_get(["type_id"], ["string"])["type_id"]
         res = []
         for ta in template_id.attachment_ids.sorted(lambda x: x.sequence):
             prod_attachment_ids = self.filtered(lambda x: x.type_id.id == ta.type_id.id)
             if prod_attachment_ids.mapped("attachment_id"):
+                non_public = prod_attachment_ids.filtered(lambda x: not x.public)
+                if non_public:
+                    non_public.sudo().write({"public": True})
                 for pa in prod_attachment_ids:
-                    if not pa.public:
-                        pa.sudo().public = True
-                    type_meta = pa.fields_get(["type_id"], ["string"])["type_id"]
                     res.append(
                         OrderedDict(
                             [

--- a/lighting_export_xlsx/models/product_auxiliary_equipment_model.py
+++ b/lighting_export_xlsx/models/product_auxiliary_equipment_model.py
@@ -11,11 +11,12 @@ class LightingProductAuxiliaryEquipmentModel(models.Model):
 
     def export_xlsx(self, template_id=None):
         valid_field = ["reference", "brand_id", "date"]
+        field_meta_base = self.fields_get(valid_field, ["string", "type"])
         res = []
         for rec in self:
             line = OrderedDict()
             for field in valid_field:
-                field_meta = self.fields_get([field], ["string", "type"])[field]
+                field_meta = field_meta_base[field]
                 datum = getattr(rec, field)
                 if field_meta["type"] in ("many2one", "many2many", "one2many"):
                     datum = datum.display_name

--- a/lighting_export_xlsx/models/product_supplier.py
+++ b/lighting_export_xlsx/models/product_supplier.py
@@ -11,11 +11,12 @@ class LightingProductSupplier(models.Model):
 
     def export_xlsx(self, template_id=None):
         valid_field = ["supplier_id", "reference"]
+        field_meta_base = self.fields_get(valid_field, ["string", "type"])
         res = []
         for rec in self.sorted(lambda x: x.sequence):
             line = OrderedDict()
             for field in valid_field:
-                field_meta = self.fields_get([field], ["string", "type"])[field]
+                field_meta = field_meta_base[field]
                 datum = getattr(rec, field)
                 if field_meta["type"] == "many2one":
                     datum = datum.display_name

--- a/lighting_export_xlsx/report/export_product_xlsx.py
+++ b/lighting_export_xlsx/report/export_product_xlsx.py
@@ -220,15 +220,14 @@ class ExportProductXlsx(models.AbstractModel):
             datum = None
         return datum
 
-    _BATCH_SIZE = 500
-
     def _generate_products(self, header, object_ids, template_id):
         n = len(object_ids)
         _logger.info("Generating %i products..." % n)
         th = int(n / 100) or 1
+        batch_size = template_id.export_batch_size
         objects_ld = []
-        for batch_start in range(0, n, self._BATCH_SIZE):
-            batch_ids = object_ids[batch_start : batch_start + self._BATCH_SIZE]
+        for batch_start in range(0, n, batch_size):
+            batch_ids = object_ids[batch_start : batch_start + batch_size]
             batch = self.env["lighting.product"].browse(batch_ids)
             for i, obj in enumerate(batch, batch_start + 1):
                 obj_d = {}

--- a/lighting_export_xlsx/report/export_product_xlsx.py
+++ b/lighting_export_xlsx/report/export_product_xlsx.py
@@ -220,34 +220,39 @@ class ExportProductXlsx(models.AbstractModel):
             datum = None
         return datum
 
+    _BATCH_SIZE = 500
+
     def _generate_products(self, header, object_ids, template_id):
         n = len(object_ids)
         _logger.info("Generating %i products..." % n)
         th = int(n / 100) or 1
         objects_ld = []
-        for i, obj_id in enumerate(object_ids, 1):
-            obj = self.env["lighting.product"].browse(obj_id)
-            obj_d = {}
-            for field, meta in header:
-                datum = self._convert_field_value(obj, field, meta, template_id)
+        for batch_start in range(0, n, self._BATCH_SIZE):
+            batch_ids = object_ids[batch_start : batch_start + self._BATCH_SIZE]
+            batch = self.env["lighting.product"].browse(batch_ids)
+            for i, obj in enumerate(batch, batch_start + 1):
+                obj_d = {}
+                for field, meta in header:
+                    datum = self._convert_field_value(obj, field, meta, template_id)
 
-                if isinstance(datum, (tuple, list)):
-                    meta["num"], obj_d = self._get_meta_num(meta, datum, obj_d)
-                else:
-                    fkey = meta["string"]
-                    if fkey in obj_d:
-                        raise Exception("The field '%s' is duplicated" % fkey)
-                    obj_d[fkey] = datum
+                    if isinstance(datum, (tuple, list)):
+                        meta["num"], obj_d = self._get_meta_num(meta, datum, obj_d)
+                    else:
+                        fkey = meta["string"]
+                        if fkey in obj_d:
+                            raise Exception("The field '%s' is duplicated" % fkey)
+                        obj_d[fkey] = datum
 
-                    if not meta["num"] and datum:
-                        meta["num"] = 1
+                        if not meta["num"] and datum:
+                            meta["num"] = 1
 
-            objects_ld.append(obj_d)
+                objects_ld.append(obj_d)
 
-            if (i % th) == 0:
-                _logger.info(
-                    " - Progress products generation %i%%" % round(i / n * 100)
-                )
+                if (i % th) == 0:
+                    _logger.info(
+                        " - Progress products generation %i%%" % round(i / n * 100)
+                    )
+            batch.invalidate_recordset()
 
         _logger.info("Products successfully generated...")
 


### PR DESCRIPTION
## Summary

- Optimize computed fields in `lighting` module (parents_brand_ids, attachment_count, finish_prefix, etc.) to use set-based SQL instead of per-record search/search_count — eliminates O(N) full table scans on 36K products
- Add missing `index=True` on FK columns across `lighting` and `lighting_etim` (product_id on attachment, source, beam, dimension tables and the 1.8M-row etim_product_feature table)
- Process XLSX export in configurable batches (new `export_batch_size` field on export template, default 500) for bounded prefetch groups and memory usage
- Cache `fields_get()` calls and batch attachment public writes in export helpers

Benchmarked on 36K products with the 345-field Novolux template:
- Before: 428ms/product (estimated 4.3h total, 504 timeout)
- After: 7.5ms/product (estimated ~5min total) — **57x speedup**

Modules affected: `lighting`, `lighting_etim`, `lighting_export`, `lighting_export_xlsx`

## Test plan

- [ ] Export with Novolux template selecting "All" products — should complete without 504
- [ ] Export with Novolux template selecting a subset — should work as before
- [ ] Verify product form views still load correctly (computed fields like parents_brand_ids, attachment_count, is_optional_accessory)
- [ ] Check that attachment URLs in export are still public after export
- [ ] Verify new "Export batch size" field appears in template Config tab and defaults to 500