### PR TITLE
[16.0][FIX] lighting_export_xlsx: fix MemoryError on binary fields during export

### DIFF
--- a/lighting_export_xlsx/report/export_product_xlsx.py
+++ b/lighting_export_xlsx/report/export_product_xlsx.py
@@ -6,7 +6,6 @@ import logging
 
 from odoo import _, fields, models
 from odoo.exceptions import ValidationError
-from odoo.tools import human_size
 
 _logger = logging.getLogger(__name__)
 
@@ -215,7 +214,9 @@ class ExportProductXlsx(models.AbstractModel):
         elif meta["type"] == "serialized":
             datum = json.dumps(datum) if datum else None
         elif meta["type"] == "binary":
-            datum = human_size(len(datum)) if datum else None
+            # With bin_size=True context, datum is already a human-readable
+            # size string (e.g. "1.16 Kb"), no conversion needed
+            datum = datum if datum else None
         if meta["type"] != "boolean" and not datum:
             datum = None
         return datum
@@ -228,7 +229,11 @@ class ExportProductXlsx(models.AbstractModel):
         objects_ld = []
         for batch_start in range(0, n, batch_size):
             batch_ids = object_ids[batch_start : batch_start + batch_size]
-            batch = self.env["lighting.product"].browse(batch_ids)
+            batch = (
+                self.env["lighting.product"]
+                .with_context(bin_size=True)
+                .browse(batch_ids)
+            )
             for i, obj in enumerate(batch, batch_start + 1):
                 obj_d = {}
                 for field, meta in header:


### PR DESCRIPTION
## Summary

- Fix MemoryError at ~66% when exporting with templates that include binary fields (e.g. `image_medium`)
- Odoo's prefetch loads all binary data for the entire 500-product batch at once, exceeding process memory
- Use `bin_size=True` context so binary fields return the file size string instead of actual data
- The export only displays file sizes in the Excel, never the binary content, so this is safe

Regression from PR #87 — the batch processing introduced prefetch groups of 500, which works fine for non-binary fields but causes memory issues with image data.

## Test plan

- [ ] Export all products with Novolux template (includes binary fields like image_medium) — should complete without MemoryError
- [ ] Verify binary field columns in the Excel show file sizes (e.g. "1.16 Kb") as before