### PR TITLE
[16.0][IMP] lighting_export_xlsx: add bin_size context to batch browse

### DIFF
--- a/lighting_export_xlsx/report/export_product_xlsx.py
+++ b/lighting_export_xlsx/report/export_product_xlsx.py
@@ -232,7 +232,11 @@ class ExportProductXlsx(models.AbstractModel):
         objects_ld = []
         for batch_start in range(0, n, batch_size):
             batch_ids = object_ids[batch_start : batch_start + batch_size]
-            batch = self.env["lighting.product"].browse(batch_ids)
+            batch = (
+                self.env["lighting.product"]
+                .with_context(bin_size=True)
+                .browse(batch_ids)
+            )
             for i, obj in enumerate(batch, batch_start + 1):
                 obj_d = {}
                 for field, meta in header:


### PR DESCRIPTION
## Summary

- Re-add `bin_size=True` on the batch browse to prevent prefetching binary field data
- This was accidentally dropped when resolving the merge conflict in PR #89
- Complements the per-field `bin_size` handling that fixes the MemoryError

## Test plan

- [ ] Export should work as before, no regression