### PR TITLE
[16.0][FIX] lighting_export_xlsx: convert bytes to str for binary fields in export

### DIFF
--- a/lighting_export_xlsx/report/export_product_xlsx.py
+++ b/lighting_export_xlsx/report/export_product_xlsx.py
@@ -198,6 +198,8 @@ class ExportProductXlsx(models.AbstractModel):
             # actual data into memory (can cause MemoryError with large
             # batches). The export only needs the file size, not the content.
             datum = obj.with_context(bin_size=True)[field]
+            if isinstance(datum, bytes):
+                datum = datum.decode("utf-8", errors="replace")
             datum = datum if datum else None
             return datum
         datum = getattr(obj, field)


### PR DESCRIPTION
## Summary

- Fix TypeError in xlsxwriter when binary fields return bytes instead of str with bin_size=True
- Decode bytes to str before returning the value to be written to Excel

## Test plan

- [ ] Export all products with Novolux template — should complete without TypeError