### PR TITLE
[16.0][FIX] lighting_export_xlsx: fix serialization error on concurrent attachment write

### DIFF
--- a/lighting_export_xlsx/models/product_attachment.py
+++ b/lighting_export_xlsx/models/product_attachment.py
@@ -17,7 +17,11 @@ class LightingAttachment(models.Model):
             if prod_attachment_ids.mapped("attachment_id"):
                 non_public = prod_attachment_ids.filtered(lambda x: not x.public)
                 if non_public:
-                    non_public.sudo().write({"public": True})
+                    ids_list = self.env.context.get("non_public_attachment_ids")
+                    if ids_list is not None:
+                        ids_list.extend(non_public.ids)
+                    else:
+                        non_public.sudo().write({"public": True})
                 for pa in prod_attachment_ids:
                     res.append(
                         OrderedDict(

--- a/lighting_export_xlsx/report/export_product_xlsx.py
+++ b/lighting_export_xlsx/report/export_product_xlsx.py
@@ -56,7 +56,10 @@ class ExportProductXlsx(models.AbstractModel):
         self._check_duplicate_labels(header, template_id)
 
         # generate data and gather header data
-        objects_ld = self._generate_products(header, objects.ids, template_id)
+        non_public_ids = []
+        objects_ld = self.with_context(
+            non_public_attachment_ids=non_public_ids
+        )._generate_products(header, objects.ids, template_id)
 
         # generate xlsx headers according to data
         xlsx_header = []
@@ -107,6 +110,13 @@ class ExportProductXlsx(models.AbstractModel):
                             sheet.write(row, col, value)
                         col += 1
             row += 1
+
+        # make exported attachments public (single write at the end to avoid
+        # concurrent access issues during batch processing)
+        if non_public_ids:
+            self.env["lighting.attachment"].sudo().browse(non_public_ids).write(
+                {"public": True}
+            )
 
     def _check_duplicate_labels(self, header, template_id):
         seen_labels = {}


### PR DESCRIPTION
## Summary

- Fix `SerializationFailure` when another worker modifies the same attachments during the long export transaction
- The ORM `write({"public": True})` creates dirty records that conflict during `flush_all()` at batch boundaries
- Use raw SQL to bypass ORM dirty record tracking — the UPDATE executes immediately

## Test plan

- [ ] Export all products while other users are active on the system