### PR TITLE
[16.0][REF] lighting_export_xlsx: pre-commit reformat

### DIFF
--- a/lighting_export_xlsx/report/export_product_xlsx.py
+++ b/lighting_export_xlsx/report/export_product_xlsx.py
@@ -114,20 +114,16 @@ class ExportProductXlsx(models.AbstractModel):
                         col += 1
             row += 1
             if (i % th) == 0:
-                _logger.info(
-                    " - Progress xlsx writing %i%%" % round(i / n * 100)
-                )
+                _logger.info(" - Progress xlsx writing %i%%" % round(i / n * 100))
         _logger.info("Xlsx writing completed...")
 
         # make exported attachments public (single write at the end to avoid
         # concurrent access issues during batch processing)
         if non_public_ids:
-            _logger.info(
-                "Setting %i attachments to public..." % len(non_public_ids)
+            _logger.info("Setting %i attachments to public..." % len(non_public_ids))
+            self.env["lighting.attachment"].sudo().browse(non_public_ids).write(
+                {"public": True}
             )
-            self.env["lighting.attachment"].sudo().browse(
-                non_public_ids
-            ).write({"public": True})
             _logger.info("Attachments updated...")
 
     def _check_duplicate_labels(self, header, template_id):


### PR DESCRIPTION
## Summary
- Pure pre-commit / Black reformat on `report/export_product_xlsx.py`: collapses three multi-line `_logger.info(...)` / `self.env[...].write(...)` calls into one-liners. No behaviour change.
- Originally bundled inside PR #95 (spare parts tab) as commit `9f2619d`. Moved here per the one-commit-one-module / one-PR-one-scope rule so #95 only touches the `lighting` module.

## Test plan
- [ ] `pre-commit run -a` passes
- [ ] CI green (Odoo/OCB)