### PR TITLE
[16.0][FIX] lighting_reporting_vanguard_product: round Flujo total to integer on datasheet

### DIFF
--- a/lighting_reporting_vanguard_product/models/lighting_product_source_line.py
+++ b/lighting_reporting_vanguard_product/models/lighting_product_source_line.py
@@ -18,13 +18,15 @@ class LightingProductSourceLine(models.Model):
         values_l.append(value)
         return " ".join(values_l)
 
-    def _get_color_temperature_flux_values(self, flux_attr):
+    def _get_color_temperature_flux_values(self, flux_attr, as_integer=False):
         self.ensure_one()
         found = False
         flux_data = []
         for flux in self.color_temperature_flux_ids:
             value = flux[flux_attr]
             if value:
+                if as_integer:
+                    value = round(value)
                 value = self.get_format_lang_decimal(value) + flux.flux_magnitude
                 if not found:
                     found = True
@@ -42,7 +44,7 @@ class LightingProductSourceLine(models.Model):
     def get_total_flux_display(self):
         self.ensure_one()
         return self._prepend_source_num(
-            self._get_color_temperature_flux_values("total_flux")
+            self._get_color_temperature_flux_values("total_flux", as_integer=True)
         )
 
     def get_total_wattage_display(self):


### PR DESCRIPTION
## Summary

- The `Flujo total` row on the Vanguard technical datasheet (`FUENTES DE LUZ` section) rendered the raw `total_flux` value through `get_format_lang_decimal`, which preserves every non-trailing-zero decimal. A value of `3516.4125` was shown as `3.516,4125 lm`, confusing Novolux's technical department and their customers.
- Reported by Gisela de la Cruz (Novolux Ecommerce Manager); final spec from Albert Orteu (Lighting Projects): **"sense cap decimal, números naturals"** — Flujo total must always render as an integer, keeping the unit.
- Fix: extend `_get_color_temperature_flux_values` with an `as_integer=False` kwarg that coerces the value with `round(...)` before handing it off to the existing `get_format_lang_decimal` helper (which uses `%g` for integer-valued numbers, matching how `nominal_flux` already renders integer values in this module). Storage and all other datasheet fields (nominal flux, wattage, color consistency, etc.) untouched.

## Test plan

- [x] Install/upgrade `lighting_reporting_vanguard_product` with `--stop-after-init` — loads clean
- [x] Browser-generated PDFs on product `989A-L0106B-01` (Vanguard / Español) via `IMPRIMIR FICHA TÉCNICA` → Odoo wizard:
  - **Before**: `Flujo total (2x) 239,39lm`
  - **After**:  `Flujo total (2x) 239lm`
  - `Flujo nominal (2x) 200lm` unchanged, full CSS/paperformat identical
- [x] Regression on products where `total_flux` is already integer (`282.0`, `152.0`, `4320.0`) — output unchanged
- [x] `pre-commit run -a` passes clean

Closes task [#2564](https://www.nuobit.com/odoo/project/6/tasks/2564).