### PR TITLE
[16.0][FIX] connector_lighting_sapb1: convert ibox_volume per SAP SVolUnit

### DIFF
--- a/connector_lighting_sapb1/components/adapter.py
+++ b/connector_lighting_sapb1/components/adapter.py
@@ -135,6 +135,7 @@ class LightingConnectorSAPB1Adapter(AbstractComponent):
         conv_mapper = {
             "/SWeight1": lambda x: float(x) or float(0),
             "/SVolume": lambda x: float(x) or float(0),
+            "/SVolUnit": lambda x: int(x) if x is not None else None,
             "/SLength1": lambda x: float(x) or float(0),
             "/SWidth1": lambda x: float(x) or float(0),
             "/SHeight1": lambda x: float(x) or float(0),

--- a/connector_lighting_sapb1/models/lighting_product/adapter.py
+++ b/connector_lighting_sapb1/models/lighting_product/adapter.py
@@ -147,8 +147,8 @@ class LightingSAPB1ProductAdapter(Component):
                                g."ItmsGrpCod", g."ItmsGrpNam", p."U_U_familia",
                                p."U_U_aplicacion",p."U_ACC_Obsmark",
                                p."U_U_Configurador", p."U_U_FECHACAT",
-                               p."SWeight1", p."SVolume", p."SLength1",
-                               p."SWidth1", p."SHeight1", s."OnHand",
+                               p."SWeight1", p."SVolume", p."SVolUnit",
+                               p."SLength1", p."SWidth1", p."SHeight1", s."OnHand",
                                s."IsCommited", s."OnOrder", s."ShipDate",
                                s."Capacity", p."AvgPrice", p."LastPurDat",
                                COALESCE(pp."PurchasePrice", 0)
@@ -178,6 +178,7 @@ class LightingSAPB1ProductAdapter(Component):
                                     COALESCE(to_binary(p."U_U_FECHACAT"), '00'), '00',
                                     COALESCE(to_binary(p."SWeight1"), '00'), '00',
                                     COALESCE(to_binary(p."SVolume"), '00'), '00',
+                                    COALESCE(to_binary(p."SVolUnit"), '00'), '00',
                                     COALESCE(to_binary(p."SLength1"), '00'), '00',
                                     COALESCE(to_binary(p."SWidth1"), '00'), '00',
                                     COALESCE(to_binary(p."SHeight1"), '00'), '00',

--- a/connector_lighting_sapb1/models/lighting_product/import_mapper.py
+++ b/connector_lighting_sapb1/models/lighting_product/import_mapper.py
@@ -94,7 +94,10 @@ class LigthingSAPB1ProductImportMapper(Component):
         if not binding or not binding.ibox_weight:
             values["ibox_weight"] = record["SWeight1"]
         if not binding or not binding.ibox_volume:
-            values["ibox_volume"] = record["SVolume"] * 1000
+            if record["SVolUnit"] == 3:
+                values["ibox_volume"] = record["SVolume"] * 1000
+            else:
+                values["ibox_volume"] = record["SVolume"]
         if not binding or not binding.ibox_length:
             values["ibox_length"] = record["SLength1"]
         if not binding or not binding.ibox_width:


### PR DESCRIPTION
The previous code multiplied SVolume by 1000 unconditionally, assuming all products use dm³ (SVolUnit=3). SAP B1 stores volumes in three different units (dm³, cm³, m³), producing 1000× inflated values for the non-dm³ products. SVolUnit is now read from SAP, included in the row hash so existing products are re-imported, and used to pick the correct multiplier into cm³ (the unit of lighting.product.ibox_volume).